### PR TITLE
Re-Organised Documentation and Readme

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
       - 'LICENSE'
       - 'config.example.toml'
       - '.gitignore'
+      - 'docs/**'
   pull_request:
     branches: [ dev ]
     paths-ignore:
@@ -14,6 +15,7 @@ on:
       - 'LICENSE'
       - 'config.example.toml'
       - '.gitignore'
+      - 'docs/**'
   workflow_dispatch:
 jobs:
   build:

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,0 +1,57 @@
+<div align="center">
+  <img src="https://raw.githubusercontent.com/AlphaNecron/Void/dev/public/banner.png" width="240" height="135"/>
+</div>
+
+# Configuration
+
+
+## Reverse proxy (nginx)
+  ```nginx
+  server {
+      listen              443 ssl;
+      server_name         your.domain;
+      ssl_certificate     /path/to/cert;
+      ssl_certificate_key /path/to/key;
+      ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+      ssl_ciphers         HIGH:!aNULL:!MD5;
+      client_max_body_size 100M;
+      location / {
+          proxy_pass http://localhost:3000;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+      }
+  }
+  ```
+
+## Config schema
+  ```toml
+  [core]
+  secure = false # Whether to use https or not
+  secret = 'supersecretpassphrase' # The secret used to sign cookie
+  host = '0.0.0.0' # The host Void should run on
+  port = 3000 # The port Void should run on
+  database_url = 'postgres://username:password@localhost:5432/db_name' # PostgreSQL database url
+
+  [bot]
+  enabled = false # Whether to enable the bot or not
+  prefix = '&' # Bot's prefix
+  token = '' # Bot's token
+  admin = [''] # Admin ids
+  log_channel = '' # The channel where logs are sent, leave blank to disable logging
+  default_uid = 1 # The default user id used to shorten and upload
+  hostname = 'example.com' # The hostname shortened urls should use in Twilight
+
+  [shortener]
+  allow_vanity = true # Whether to allow vanity urls or not
+  length = 6 # Slug length
+  route = '/go' # Route to serve shortened urls
+
+  [uploader]
+  raw_route = '/r' # Route to serve raw contents
+  length = 6 # Slug length
+  directory = './uploads' # The directory where images are stored
+  max_size = 104857600 # Max upload size (users only), in bytes
+  blacklisted = ['exe'] # Blacklisted file extensions (users only)
+  ```

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -55,3 +55,12 @@
   max_size = 104857600 # Max upload size (users only), in bytes
   blacklisted = ['exe'] # Blacklisted file extensions (users only)
   ```
+
+## Bot permissions
+  **These permissions are required for the bot to work properly (27712):**
+  
+    - Add reactions
+    - Read messages
+    - Send messages 
+    - Manage messages
+    - Embed links

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -4,6 +4,10 @@
 
 # Installation
 
+**Default credentials**
+  - Username: `admin`
+  - Password: `voiduser`
+
 With Void there are 3 ways to install and deploy:
 1. [Manual](#manual)
 2. [Docker](#Docker)

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,0 +1,48 @@
+<div align="center">
+  <img src="https://raw.githubusercontent.com/AlphaNecron/Void/dev/public/banner.png" width="240" height="135"/>
+</div>
+
+# Installation
+
+With Void there are 3 ways to install and deploy:
+1. [Manual](#manual)
+2. [Docker](#Docker)
+3. [Docker compose](#Docker-compose)
+
+## Manual
+  **Requirements**
+  
+  - `node` >= 14
+  - PostgreSQL
+  - Either `yarn` or `npm`
+  
+  **Install**
+  
+  ```sh
+  git clone https://github.com/AlphaNecron/Void.git
+  cd Void
+  yarn install # or npm install
+  cp config.example.toml config.toml
+  nano config.toml # edit the config file
+  yarn build # or npm run build
+  yarn start # or npm start
+  ```
+
+## Docker
+  ```sh
+  git clone https://github.com/AlphaNecron/Void.git
+  cd Void
+  cp config.example.toml config.toml
+  nano config.toml # edit the config file
+  docker pull alphanecron/void:v0
+  docker run -p 3000:3000 -v $PWD/config.toml:/void/config.toml -d alphanecron/void:v0
+  ```
+
+## Docker compose
+  ```sh
+  git clone https://github.com/AlphaNecron/Void.git
+  cd Void
+  cp config.example.toml config.toml
+  nano config.toml # edit the config file
+  docker-compose up --build -d
+  ```

--- a/readme.md
+++ b/readme.md
@@ -9,92 +9,6 @@
   ![Last commit](https://img.shields.io/github/last-commit/AlphaNecron/Void/dev?color=%234FD1C5&logo=github&style=for-the-badge)
 </div>
 
-### Requirements
-  - `node` >= 14
-  - PostgreSQL
-  - Either `yarn` or `npm`
-
-### Installation / Deployment
-  ```sh
-  git clone https://github.com/AlphaNecron/Void.git
-  cd Void
-  yarn install # or npm install
-  cp config.example.toml config.toml
-  nano config.toml # edit the config file
-  yarn build # or npm run build
-  yarn start # or npm start
-  ```
-
-### Docker
-  ```sh
-  git clone https://github.com/AlphaNecron/Void.git
-  cd Void
-  cp config.example.toml config.toml
-  nano config.toml # edit the config file
-  docker pull alphanecron/void:v0
-  docker run -p 3000:3000 -v $PWD/config.toml:/void/config.toml -d alphanecron/void:v0
-  ```
-
-### Docker compose
-  ```sh
-  git clone https://github.com/AlphaNecron/Void.git
-  cd Void
-  cp config.example.toml config.toml
-  nano config.toml # edit the config file
-  docker-compose up --build -d
-  ```
-
-### Reverse proxy (nginx)
-  ```nginx
-  server {
-      listen              443 ssl;
-      server_name         your.domain;
-      ssl_certificate     /path/to/cert;
-      ssl_certificate_key /path/to/key;
-      ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
-      ssl_ciphers         HIGH:!aNULL:!MD5;
-      client_max_body_size 100M;
-      location / {
-          proxy_pass http://localhost:3000;
-          proxy_set_header Host $host;
-          proxy_set_header X-Real-IP $remote_addr;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header X-Forwarded-Proto $scheme;
-      }
-  }
-  ```
-
-### Config schema
-  ```toml
-  [core]
-  secure = false # Whether to use https or not
-  secret = 'supersecretpassphrase' # The secret used to sign cookie
-  host = '0.0.0.0' # The host Void should run on
-  port = 3000 # The port Void should run on
-  database_url = 'postgres://username:password@localhost:5432/db_name' # PostgreSQL database url
-
-  [bot]
-  enabled = false # Whether to enable the bot or not
-  prefix = '&' # Bot's prefix
-  token = '' # Bot's token
-  admin = [''] # Admin ids
-  log_channel = '' # The channel where logs are sent, leave blank to disable logging
-  default_uid = 1 # The default user id used to shorten and upload
-  hostname = 'example.com' # The hostname shortened urls should use in Twilight
-
-  [shortener]
-  allow_vanity = true # Whether to allow vanity urls or not
-  length = 6 # Slug length
-  route = '/go' # Route to serve shortened urls
-
-  [uploader]
-  raw_route = '/r' # Route to serve raw contents
-  length = 6 # Slug length
-  directory = './uploads' # The directory where images are stored
-  max_size = 104857600 # Max upload size (users only), in bytes
-  blacklisted = ['exe'] # Blacklisted file extensions (users only)
-  ```
-
 ### Features
   - Configurable
   - Fast and reliable
@@ -112,20 +26,12 @@
   - Password-protected URL
   - Embed customization (with variables)
 
+### Docs
+  - [How to Install](https://github.com/AlphaNecron/Void/tree/dev/docs/Installation.md)
+  - [How to Configure](https://github.com/AlphaNecron/Void/tree/dev/docs/Configuration.md)
+
 ### Contribution
   - All pull requests must be made in `dev` branch, pull requests in `v0` will be closed.
-
-### Default credentials
-  - Username: `admin`
-  - Password: `voiduser`
-
-### Bot permissions
-  #### These permissions are required for the bot to work properly (27712):
-    - Add reactions
-    - Read messages
-    - Send messages 
-    - Manage messages
-    - Embed links
 
 ### Todo
   - Discord integration
@@ -134,3 +40,4 @@
 ### Credits
   - Source code and API from `diced/zipline`
   - Logo and favicon from `icons8`
+  - Documentation from `chelsea-fox`


### PR DESCRIPTION
I have separated the large readme.md to `docs/Installation.md` & `Configuration.md`

This way the readme file is smaller and much more elegant whilst keeping the important documentation still easily accessible.

This also allows for future changes to the documentation in case there are large scale changes in the future. 